### PR TITLE
Fix bug preventing destructiveIndex to be set to zero

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ export default class PopupMenu extends React.Component {
         let options = this.props.options;
         if (Platform.OS === "ios") {
             let destructiveIndex = -1;
-            if (this.props.destructiveIndex) {
+            if (Number.isInteger(this.props.destructiveIndex) && this.props.destructiveIndex >= 0) {
                 destructiveIndex = this.props.destructiveIndex;
             }
             ActionSheetIOS.showActionSheetWithOptions(


### PR DESCRIPTION
This fixes a bug which was preventing the use of `destructiveIndex` on the first option.

![image](https://user-images.githubusercontent.com/7222609/43996988-c0c53d9c-9dc7-11e8-8175-97e38100eb7f.png)
