### PR TITLE
Adding possibility to change the trigger component

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ Options: an array of strings that will be displayed in the menu.
 
 Actions: an array of functions to be executed for every menu item. Note that the orders of options an actions have to match.
 
+By default the component used to handle the menu triggering is a `TouchableOpacity`, that can be changed by using the `triggerComponent` prop, where you can pass any other component (like `TouchableHighlight` for example) to handle that event. Custom made components can also be used, but those components need to able to handle the `ref` and `onPress` properties to work properly.
+
 
 iOS Screenshot: 
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Options: an array of strings that will be displayed in the menu.
 
 Actions: an array of functions to be executed for every menu item. Note that the orders of options an actions have to match.
 
-By default the component used to handle the menu triggering is a `TouchableOpacity`, that can be changed by using the `triggerComponent` prop, where you can pass any other component (like `TouchableHighlight` for example) to handle that event. Custom made components can also be used, but those components need to able to handle the `ref` and `onPress` properties to work properly.
+By default the component used to handle the menu triggering is a `TouchableOpacity`, that can be changed by using the `renderTriggerComponent` prop, where you can pass a function responsible to render the trigger component, that function must receive the following parameters `children`, `ref`, `onPress`, and return the Component.
 
 
 iOS Screenshot: 

--- a/index.js
+++ b/index.js
@@ -115,15 +115,16 @@ export default class PopupMenu extends React.Component {
       this.props.customButton
     );
 
-    const TriggerComponent = this.props.triggerComponent || TouchableOpacity;
+		const renderTriggerComponent =
+      this.props.renderTriggerComponent
+      || ((children, ref, onPress) => (<TouchableOpacity ref={ref} onPress={onPress}>{children}</TouchableOpacity>));
+
 
     if (Platform.OS === "web") {
       return (
         <View>
           <View>
-            <TriggerComponent ref={"menu"} onPress={this.handlePressWeb}>
-              {component}
-            </TriggerComponent>
+				{renderTriggerComponent(component, "menu", this.handlePressWeb)}
           </View>
           {options}
         </View>
@@ -131,11 +132,10 @@ export default class PopupMenu extends React.Component {
     } else {
       return (
         <View>
-          <TriggerComponent ref={"menu"} onPress={this.handlePress}>
-            {component}
-          </TriggerComponent>
+				{renderTriggerComponent(component, "menu", this.handlePress)}
         </View>
       );
     }
   }
 }
+

--- a/index.js
+++ b/index.js
@@ -8,7 +8,6 @@ import {
   TouchableOpacity,
   Image,
   Text,
-  TextInput
 } from "react-native";
 
 export default class PopupMenu extends React.Component {
@@ -115,13 +114,16 @@ export default class PopupMenu extends React.Component {
     ) : (
       this.props.customButton
     );
+
+    const TriggerComponent = this.props.triggerComponent || TouchableOpacity;
+
     if (Platform.OS === "web") {
       return (
         <View>
           <View>
-            <TouchableOpacity ref={"menu"} onPress={this.handlePressWeb}>
+            <TriggerComponent ref={"menu"} onPress={this.handlePressWeb}>
               {component}
-            </TouchableOpacity>
+            </TriggerComponent>
           </View>
           {options}
         </View>
@@ -129,9 +131,9 @@ export default class PopupMenu extends React.Component {
     } else {
       return (
         <View>
-          <TouchableOpacity ref={"menu"} onPress={this.handlePress}>
+          <TriggerComponent ref={"menu"} onPress={this.handlePress}>
             {component}
-          </TouchableOpacity>
+          </TriggerComponent>
         </View>
       );
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,5 @@
+{
+  "name": "react-native-options-menu",
+  "version": "2.0.1",
+  "lockfileVersion": 1
+}


### PR DESCRIPTION
Hi, thanks for this package!

On a project I work, we need to be able to use a different component than `TouchableOpacity, so we can keep things inside our Design System rules.

For that I have added a new `prop` called `triggerComponent`, where you can pass what component you wish to be used, this is an optional property which falls to the `TouchableOpacity` if no value is provided, so this does no create a breaking change.

Let me know if this is acceptable.